### PR TITLE
Query cancellation

### DIFF
--- a/tests/query-cancellation.js
+++ b/tests/query-cancellation.js
@@ -1,0 +1,17 @@
+var test = require('tape')
+var ConnectionPool = require('../')
+var mockAdapter = require('any-db-fake')
+
+test('ConnectionPool.prototype.cancel', function (t) {
+  var pool = ConnectionPool(mockAdapter(), "")
+  var query = pool.query("SELECT 1 FROM some_table", callback)
+
+  // cancel the query synchronously
+  pool.cancel(query)
+
+  function callback(err, result) {
+    t.ok(err, "Expected CancelledQueryError, but no error received")
+    t.equal(''+err, "CancelledQueryError: Query was cancelled before connection was acquired")
+    t.end()
+  }
+})


### PR DESCRIPTION
This is a quick implementation of cancellation for queries that have not yet been passed off to a connection (as described in #15).

@bradleygore could you test this out and see if it helps with your use case? If so I would merge and release a new version.